### PR TITLE
Edit Html Id from Site Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- You are now able to edit the `"htmlId"` prop from Site Editor
 
 ## [0.2.0] - 2022-02-18
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The app only supports the very basics:
 * composition of children
 * Block classes
 * **NEW** - YES! The ID makes sense. Now you have it! Feel free to drop IDs starting at version 0.2.0 via the prop "htmlId"
+* **NEW** - You are now able to edit the `"htmlId"` prop from Site Editor
 
 ```json
 "just-a-div#aroundthelinks": {

--- a/react/justDiv.tsx
+++ b/react/justDiv.tsx
@@ -34,7 +34,15 @@ const justDiv: StorefrontFunctionComponent<justDivProps> = (
 justDiv.schema = {
   title: 'editor.field.title',
   description: 'editor.field.description',
-  type: 'object', 
+  type: 'object',
+  properties: {
+    htmlId: {
+       title: 'Html Id',
+       description: 'HTML Id Attribute of justDiv',
+       type: 'string',
+       default: null,
+     },
+ },
 }
 
 export default justDiv


### PR DESCRIPTION
This feature allows you to edit the `"htmlId"` from Site Editor.

Open Site Editor and click on justaDiv on the side menu, this will open an edit menu, like the one shown below:

![image](https://user-images.githubusercontent.com/77269087/174996715-dae9a96a-51e3-43ce-ab0e-e79d67287793.png)
